### PR TITLE
fix: handle section reference scrolling

### DIFF
--- a/src/components/Section/cmp.tsx
+++ b/src/components/Section/cmp.tsx
@@ -5,10 +5,14 @@ import { SectionProps } from "./types";
 import { StyledSection } from "./styles";
 
 export const Section = ({ children, effects, id, ...props }: SectionProps) => {
-  const calculatedClassName = [`${effects || ""}`, `scrollTo-${id}`].join(" ");
+  const calculatedClassName = [`${effects || ""}`].join(" ");
 
   return (
-    <StyledSection className={calculatedClassName} {...props}>
+    <StyledSection
+      className={calculatedClassName}
+      id={id ? `scroll-${id}` : undefined}
+      {...props}
+    >
       {children}
     </StyledSection>
   );

--- a/src/components/Section/cmp.tsx
+++ b/src/components/Section/cmp.tsx
@@ -5,10 +5,10 @@ import { SectionProps } from "./types";
 import { StyledSection } from "./styles";
 
 export const Section = ({ children, effects, id, ...props }: SectionProps) => {
-  const calculatedClassName = `${effects || ""}`;
+  const calculatedClassName = [`${effects || ""}`, `scrollTo-${id}`].join(" ");
 
   return (
-    <StyledSection className={calculatedClassName} id={id} {...props}>
+    <StyledSection className={calculatedClassName} {...props}>
       {children}
     </StyledSection>
   );

--- a/src/pages/_dynamicPage.tsx
+++ b/src/pages/_dynamicPage.tsx
@@ -7,7 +7,6 @@ import { useRouter } from "next/router";
 import "../builder-registry";
 import StickyComponent from "@/components/StickyComponent";
 import { Loading } from "./_loading";
-import { themes } from "@aleph-front/core";
 
 type DynamicPageProps = {
   pageModel?: string;
@@ -26,29 +25,23 @@ export default function DynamicPage({
   const [notFound, setNotFound] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const getHeaderOffset = () => {
-    const header = document.getElementsByTagName("header")[0];
-    return header ? header.offsetHeight : 0;
-  };
-
   useEffect(() => {
     async function scrollToElement() {
       const [_urlPath, hash] = router.asPath.split("#") || "/";
+      if (!hash) return;
 
-      if (hash) {
-        const element = document.getElementsByClassName(`scrollTo-${hash}`)[0];
-        themes.aleph;
+      const element = document.getElementById(`scroll-${hash}`);
+      if (!element) return;
 
-        if (element) {
-          const bounding = element.getBoundingClientRect();
-          const top = bounding.top + window.scrollY;
+      const bounding = element.getBoundingClientRect();
+      const top = bounding.top + window.scrollY;
+      const headerOffset =
+        document.getElementsByTagName("header")[0]?.offsetHeight || 0;
 
-          window.scrollTo({
-            top: top - getHeaderOffset(),
-            behavior: "smooth",
-          });
-        }
-      }
+      window.scrollTo({
+        top: top - headerOffset,
+        behavior: "smooth",
+      });
     }
 
     scrollToElement();

--- a/src/pages/_dynamicPage.tsx
+++ b/src/pages/_dynamicPage.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/router";
 import "../builder-registry";
 import StickyComponent from "@/components/StickyComponent";
 import { Loading } from "./_loading";
+import { themes } from "@aleph-front/core";
 
 type DynamicPageProps = {
   pageModel?: string;
@@ -25,9 +26,37 @@ export default function DynamicPage({
   const [notFound, setNotFound] = useState(false);
   const [loading, setLoading] = useState(true);
 
+  const getHeaderOffset = () => {
+    const header = document.getElementsByTagName("header")[0];
+    return header ? header.offsetHeight : 0;
+  };
+
+  useEffect(() => {
+    async function scrollToElement() {
+      const [_urlPath, hash] = router.asPath.split("#") || "/";
+
+      if (hash) {
+        const element = document.getElementsByClassName(`scrollTo-${hash}`)[0];
+        themes.aleph;
+
+        if (element) {
+          const bounding = element.getBoundingClientRect();
+          const top = bounding.top + window.scrollY;
+
+          window.scrollTo({
+            top: top - getHeaderOffset(),
+            behavior: "smooth",
+          });
+        }
+      }
+    }
+
+    scrollToElement();
+  }, [router.asPath]);
+
   useEffect(() => {
     async function fetchContent() {
-      const urlPath = router.asPath.split("#")[0] || "/";
+      const [urlPath, _hash] = router.asPath.split("#") || "/";
 
       try {
         setLoading(true);
@@ -65,10 +94,8 @@ export default function DynamicPage({
     }
 
     fetchContent();
-  }, [router.asPath, page]); // Depend on router.asPath to refetch content on route changes
+  }, [router.asPath, page]);
 
-  // If the page content is available, render
-  // the BuilderComponent with the page content
   return (
     <>
       <Head>
@@ -82,7 +109,6 @@ export default function DynamicPage({
           />
         </StickyComponent>
       )}
-      {/* Render the Builder page */}
       <main tw="min-h-[100vh]">
         <Loading show={loading} />
         {notFound && !isPreviewing ? (


### PR DESCRIPTION
1. Finds element X with class `scrollTo-${hash}`
2. Calculates top position of the element X
3. Calculates header element height offset (returns 0 if no header found)
4. Scrolls to top of found element X substracting the header element height offset