### PR TITLE
fix: configure .npmrc to run pre & post scripts

### DIFF
--- a/.github/workflows/build_check.yaml
+++ b/.github/workflows/build_check.yaml
@@ -23,5 +23,8 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
           NEXT_PUBLIC_BUILDER_API_KEY: whatever
         run: |
+          npm config set "@fortawesome:registry" https://npm.fontawesome.com/
+          npm config set "//npm.fontawesome.com/:_authToken" FONTAWESOME_NPM_AUTH_TOKEN
+          npm config set "enable-pre-post-scripts" true
           npm ci
           npm run build

--- a/.github/workflows/build_check.yaml
+++ b/.github/workflows/build_check.yaml
@@ -23,7 +23,5 @@ jobs:
           FONTAWESOME_NPM_AUTH_TOKEN: ${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}
           NEXT_PUBLIC_BUILDER_API_KEY: whatever
         run: |
-          npm config set "@fortawesome:registry" https://npm.fontawesome.com/
-          npm config set "//npm.fontawesome.com/:_authToken" FONTAWESOME_NPM_AUTH_TOKEN
           npm ci
           npm run build

--- a/.github/workflows/push_on_ipfs.yaml
+++ b/.github/workflows/push_on_ipfs.yaml
@@ -34,8 +34,6 @@ jobs:
           NEXT_PUBLIC_BUILDER_API_KEY: ${{ matrix.key }}
           SITE_HOME_URL: ${{ matrix.siteHomeUrl }}
         run: |
-          npm config set "@fortawesome:registry" https://npm.fontawesome.com/
-          npm config set "//npm.fontawesome.com/:_authToken" FONTAWESOME_NPM_AUTH_TOKEN
           npm ci
           npm run build
           touch out/.nojekyll

--- a/.github/workflows/push_on_ipfs.yaml
+++ b/.github/workflows/push_on_ipfs.yaml
@@ -34,6 +34,9 @@ jobs:
           NEXT_PUBLIC_BUILDER_API_KEY: ${{ matrix.key }}
           SITE_HOME_URL: ${{ matrix.siteHomeUrl }}
         run: |
+          npm config set "@fortawesome:registry" https://npm.fontawesome.com/
+          npm config set "//npm.fontawesome.com/:_authToken" FONTAWESOME_NPM_AUTH_TOKEN
+          npm config set "enable-pre-post-scripts" true
           npm ci
           npm run build
           touch out/.nojekyll

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 @fortawesome:registry=https://npm.fontawesome.com/
 //npm.fontawesome.com/:_authToken=${FONTAWESOME_NPM_AUTH_TOKEN}
+enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "next-sitemap  --config ./next-sitemap.config.js",
+    "postbuild": "next-sitemap --config ./next-sitemap.config.js",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Following [next-sitemap docs](https://github.com/iamvishnusankar/next-sitemap?tab=readme-ov-file#building-sitemaps-with-pnpm), added `enable-pre-post-scripts=true` config line in .npmrc

